### PR TITLE
Fix sprintf() error on PHP 8

### DIFF
--- a/src/StemmerFactory.php
+++ b/src/StemmerFactory.php
@@ -49,6 +49,6 @@ class StemmerFactory
             }
         }
 
-        throw new NotFoundException(sprintf('Stemmer not found for %', $code));
+        throw new NotFoundException(sprintf('Stemmer not found for %s', $code));
     }
 }


### PR DESCRIPTION
Fixes "Missing format specifier at end of string" error on PHP 8.

To reproduce the error, call `StemmerFactory::create()` with not supported language code.