### PR TITLE
PHP 8.2 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.3, 7.4, 8.0, 8.1, 8.2]
+        stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
 
@@ -32,7 +33,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --prefer-dist --no-interaction --no-progress
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Copy PHP Unit Settings
         run: cp phpunit.xml.dist phpunit.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1]
+        php: [7.3, 7.4, 8.0, 8.1, 8.2]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=7.3",
-		"voku/portable-utf8": "^5.4"
+		"voku/portable-utf8": "^5.4|^6.0"
 	},
 	"require-dev":{
 		"phpunit/phpunit": "^9.0"


### PR DESCRIPTION
This PR updates `voku/portable-utf8` where a string interpolation deprecation has been fixed.

It also updates the test files to match the iterator parent return types. This upgrade means that the tests will only run on PHP 8.0 and above, due to `mixed` not being available on earlier versions. However, this matches the official supported versions https://www.php.net/supported-versions.php

<img width="1334" alt="image" src="https://user-images.githubusercontent.com/571773/206955351-5dd71728-4321-4892-aed5-e8a042eed958.png">

I've preemptively updated the README assuming there will be a new major version released.

I've also added a github actions workflow to test PHP 8.0, 8.1 and 8.2 but Actions will need to be turned [on for this repo](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository). There may need to be changes to the file after it has been ran. I'm just basing it off other files across public and my private repos.