### PR TITLE
Support voku/portable-utf8:^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=7.3",
-		"voku/portable-utf8": "^5.4"
+		"voku/portable-utf8": "^5.4|^6.0"
 	},
 	"require-dev":{
 		"phpunit/phpunit": "^9.0"


### PR DESCRIPTION
This PR adds support for [`voku/portable-utf8:^6.0`](https://github.com/voku/portable-utf8). The new version should be fully compatible since only the following methods are used:
```php
UTF8::strpos()
UTF8::is_utf8()
UTF8::substr()
UTF8::str_replace()
UTF8::strtolower()
UTF8::strlen()
UTF8::to_ascii()
UTF8::to_utf8()
```

All of these methods are still available in v6 of the library.