### PR TITLE
php 8.2 deprecation

### DIFF
--- a/src/NotFoundException.php
+++ b/src/NotFoundException.php
@@ -4,5 +4,5 @@ namespace Wamania\Snowball;
 
 class NotFoundException extends \Exception
 {
-
+    public $xdebug_message;
 }


### PR DESCRIPTION
with  php 8.2
Deprecated: Creation of dynamic property Wamania\Snowball\NotFoundException::$xdebug_message